### PR TITLE
Feature: multithreading api

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,4 @@
 client-server-api/server/cotacao.db
 client-server-api/client/cotacao.txt
+
+.vscode/*

--- a/multithreading-api/go.mod
+++ b/multithreading-api/go.mod
@@ -1,0 +1,5 @@
+module github.com/allsou/pos-goexpert/multithreading-api
+
+go 1.23.2
+
+require github.com/gorilla/mux v1.8.1

--- a/multithreading-api/go.sum
+++ b/multithreading-api/go.sum
@@ -1,0 +1,2 @@
+github.com/gorilla/mux v1.8.1 h1:TuBL49tXwgrFYWhqrNgrUNEY92u81SPhu7sTdzQEiWY=
+github.com/gorilla/mux v1.8.1/go.mod h1:AKf9I4AEqPTmMytcMc0KkNouC66V3BtZ4qD5fmWSiMQ=

--- a/multithreading-api/main.go
+++ b/multithreading-api/main.go
@@ -1,0 +1,85 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"net/http"
+	"time"
+
+	"github.com/gorilla/mux"
+)
+
+func requestBrasilAPI(cep string, ch chan<- map[string]string, errCh chan<- error) {
+	url := fmt.Sprintf("https://brasilapi.com.br/api/cep/v1/%s", cep)
+	resp, err := http.Get(url)
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer resp.Body.Close()
+
+	var address map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&address); err != nil {
+		errCh <- err
+		return
+	}
+	address["api_datasource"] = "BrasilAPI"
+
+	ch <- address
+}
+
+func requestViaCEP(cep string, ch chan<- map[string]string, errCh chan<- error) {
+	url := fmt.Sprintf("http://viacep.com.br/ws/%s/json/", cep)
+	resp, err := http.Get(url)
+	if err != nil {
+		errCh <- err
+		return
+	}
+	defer resp.Body.Close()
+
+	var address map[string]string
+	if err := json.NewDecoder(resp.Body).Decode(&address); err != nil {
+		errCh <- err
+		return
+	}
+	address["api_datasource"] = "ViaCEP"
+
+	ch <- address
+}
+
+func main() {
+	r := mux.NewRouter()
+
+	r.HandleFunc("/ceps/{cep}", func(w http.ResponseWriter, r *http.Request) {
+		vars := mux.Vars(r)
+
+        var cep string
+		cep = vars["cep"]
+        if len(cep) != 8 {
+            http.Error(w, "CEP inválido", http.StatusBadRequest)
+            return
+        }
+
+		ch := make(chan map[string]string)
+		errCh := make(chan error)
+
+		ctx, cancel := context.WithTimeout(context.Background(), 1*time.Second)
+		defer cancel()
+
+		go requestBrasilAPI(cep, ch, errCh)
+		go requestViaCEP(cep, ch, errCh)
+
+		select {
+		case address := <-ch:
+			fmt.Printf("Endereço recebido: %+v\n", address)
+			cancel()
+		case err := <-errCh:
+			fmt.Println("Erro ao buscar endereço:", err)
+		case <- ctx.Done():
+			fmt.Println("Timeout: Nenhuma API respondeu a tempo.")
+		}
+	})
+
+	http.ListenAndServe(":8080", r)
+}


### PR DESCRIPTION
Neste desafio você terá que usar o que aprendemos com Multithreading e APIs para buscar o resultado mais rápido entre duas APIs distintas.

As duas requisições serão feitas simultaneamente para as seguintes APIs:

https://brasilapi.com.br/api/cep/v1/01153000 + cep

http://viacep.com.br/ws/" + cep + "/json/

Os requisitos para este desafio são:

- Acatar a API que entregar a resposta mais rápida e descartar a resposta mais lenta.

- O resultado da request deverá ser exibido no command line com os dados do endereço, bem como qual API a enviou.

- Limitar o tempo de resposta em 1 segundo. Caso contrário, o erro de timeout deve ser exibido.